### PR TITLE
Fix End of Line for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+*.bat eol=crlf
+*.cmd eol=crlf


### PR DESCRIPTION
Last PR #2 was fine, but git automatically convert CRLF to LF, which makes those batch files not executable on Windows.

Add `.gitattributes` file to convert those files back to CRLF.