### PR TITLE
fix direction argument check for being an integer

### DIFF
--- a/plugins/board/board/neighbors/GetNeighborTileXY.js
+++ b/plugins/board/board/neighbors/GetNeighborTileXY.js
@@ -1,7 +1,7 @@
 var GetNeighborTileXY = function (srcTileXY, directions, out) {
     var dir, neighborTileXY;
 
-    if (typeof (directions) === 'number') {
+    if (isNaN(parseInt(directions)) === false) {
         dir = directions;
         if (out === undefined) {
             out = {};
@@ -18,7 +18,7 @@ var GetNeighborTileXY = function (srcTileXY, directions, out) {
         }
         return out;
 
-    } else {
+    } else if (Array.isArray(directions) || directions == null) {
         // directions array
         if (directions == null) {
             directions = this.grid.allDirections;
@@ -38,6 +38,7 @@ var GetNeighborTileXY = function (srcTileXY, directions, out) {
             });
         }
         return out;
-    }
+    } else
+        throw "Error: unsupported 'directions' argument type: must be integer, array or null!";
 };
 export default GetNeighborTileXY;


### PR DESCRIPTION
just spent half an our debbugging that issue.

the point is that, for example, board.getNeighborTileDirection(srcTile, neighborTileXY) returns value that is than is not accepted by GetNeighborTileXY because of not being typeof number, I didn't get into details why, but that will not work as expected:

let direction = board.getNeighborTileDirection(tileXYZ_before, tileXYZ_after);
let throw_target_XY = board.getNeighborTileXY(tileXYZ_after, direction); < ----- direction is not typeof number so is threated like null or array in else block of the function above

but that will work as expected

let direction = board.getNeighborTileDirection(tileXYZ_before, tileXYZ_after);
let throw_target_XY = board.getNeighborTileXY(tileXYZ_after, parseInt(direction));

So I suggest changing the check a little to support both numbers and number strings and make its behaviour more obvious.
The only change to the check logic is that now it will handle number strings as numbers too