### PR TITLE
Allow GetNeighborChess to receive TileXY, not only chess

### DIFF
--- a/plugins/board/board/neighbors/GetNeighborChess.js
+++ b/plugins/board/board/neighbors/GetNeighborChess.js
@@ -1,5 +1,10 @@
-var GetNeighborChess = function (chess, directions, neighborTileZ, out) {
-    var tileXYZ = this.chessToTileXYZ(chess);
+var GetNeighborChess = function (chessOrTileXYZ, directions, neighborTileZ, out) {
+    var tileXYZ;
+    if (chessOrTileXYZ.x && chessOrTileXYZ.y && chessOrTileXYZ.z) {
+        tileXYZ = chessOrTileXYZ;
+    } else {
+        tileXYZ = this.chessToTileXYZ(chessOrTileXYZ);
+    }
     if (tileXYZ === null) {
         return null;
     }


### PR DESCRIPTION
Hello! It is sometimes necessary for my game logic to check for neighbor chess of some tile before moving there. As I see now we can only get all neighbour chess of a chess, not TileXY.
I will be glad if you don't mind adding that addition in any way you see it. Thanks!