### PR TITLE
Fix NinePatch import string

### DIFF
--- a/templates/ui/ui-components.js
+++ b/templates/ui/ui-components.js
@@ -4,7 +4,7 @@ import TagText from './tagtext/TagText.js';
 import Container from './container/Container.js';
 import Chart from './chart/Chart.js';
 import CircleMaskImage from './circlemaskimage/CircleMaskImage.js';
-import NinePatch from './ninepatch/.NinePatchjs';
+import NinePatch from './ninepatch/NinePatch.js';
 import YoutubePlayer from './youtubeplayer/YoutubePlayer.js';
 
 import Sizer from './sizer/Sizer.js';


### PR DESCRIPTION
This PR fixes a typo inside of `ui/ui-components.js` where it does not properly import NinePatch.js

```
ERROR in ./node_modules/phaser3-rex-plugins/templates/ui/ui-components.js
Module not found: Error: Can't resolve './ninepatch/.NinePatchjs' in '/Users/art/code/xia/node_modules/phaser3-rex-plugins/templates/ui'
 @ ./node_modules/phaser3-rex-plugins/templates/ui/ui-components.js 7:0-49 48:0-93:1
 @ ./src/components/BuilderTable.js
 @ ./src/scenes/Builder.js
 @ ./src/scenes/index.js
 @ ./src/index.js
```