### PR TITLE
Board: emit pointerout event on a previous tile

### DIFF
--- a/plugins/board/board/input/OnPointerMove.js
+++ b/plugins/board/board/input/OnPointerMove.js
@@ -37,7 +37,7 @@ var OnPointerMove = function (pointer) {
     EmitChessEvent(
         'gameobjectout',
         'board.pointerout',
-        board, tileX, tileY,
+        board, this.prevTilePosition.x, this.prevTilePosition.y,
         pointer
     );
 


### PR DESCRIPTION
Currently `gameobjectout` and `board.pointerout` events are fired not on the previous chess as the `tileout` event, but for a tile under the cursor.

Here is an example: https://codepen.io/ProgressoRU/pen/abdmgEP

I believe this issue can be easily fixed by changing `tileX, tileY` in this block with `this.prevTilePosition.x, this.prevTilePosition.y`
https://github.com/rexrainbow/phaser3-rex-notes/blob/9e74105e3448a26edb79677e37b5c1c89a45fe25/plugins/board/board/input/OnPointerMove.js#L37-L42