### PR TITLE
Fix typo 'surce' -> 'source'

### DIFF
--- a/docs/docs/particles.md
+++ b/docs/docs/particles.md
@@ -267,7 +267,7 @@ emitter.setEmitZone({
     - [Curve](path.md) source has *quantity*, or *stepRate*
     - [Path](path.md) source only has *quantity*
 
-#### Curve surce
+#### Curve source
 
 - Get curve source
     ```javascript


### PR DESCRIPTION
Fixes a minor typo.

I tried to build the docs to test it by running `upgrade.bat` and `build.bat` from `./docs/` but it fails to build on `mkdocs-material` 6.2.2 in Python 3.8.5. Looks like `mkdocs-material` has some breaking changes in the latest version, which makes the version installed by `upgrade.bat` not work, FYI: https://github.com/mkdocs/mkdocs/issues/2156#issuecomment-673482097