### PR TITLE
Fix imported file name for outline pipeline plugin

### DIFF
--- a/plugins/outlinepipeline-plugin.js
+++ b/plugins/outlinepipeline-plugin.js
@@ -1,4 +1,4 @@
-import OutlinePostFxPipeline from './OutlinePipeline.js';
+import OutlinePostFxPipeline from './outlinepipeline.js';
 import BasePostFxPipelinePlugin from './utils/renderer/BasePostFxPipelinePlugin.js';
 import SetValue from './utils/object/SetValue.js';
 


### PR DESCRIPTION
This fixes importing the outlinepipeline plugin for case sensitive file systems.