### PR TITLE
Outline shader math optimized for 1px

### DIFF
--- a/plugins/shaders/outline/outline-postfxfrag.js
+++ b/plugins/shaders/outline/outline-postfxfrag.js
@@ -25,7 +25,7 @@ vec4 GetOutlineColor(vec4 front, float width, vec3 color) {
     vec4 curColor;
     float maxAlpha = front.a;
     vec2 offset;
-    for (float angle = 0.; angle <= DOUBLE_PI; angle += 0.6283185) {
+    for (float angle = 0.; angle < DOUBLE_PI; angle += 0.785398) {
         offset = vec2(mag.x * cos(angle), mag.y * sin(angle));        
         curColor = texture2D(uMainSampler, outTexCoord + offset);
         maxAlpha = max(maxAlpha, curColor.a);


### PR DESCRIPTION
I threw this together rather than ask why it's written the way that it is, so please feel free to reject if my changes don't make sense!

As written, the code went from 0->2*pi (both ends inclusive) in increments of ~36 degrees, and sampled one point at each offset.
It was sampling 2pi twice (once at 0, and again when 10 * 35.9999982401 = 359.999982401 degrees); also, it was oddly grid aligned especially for small width values like 1.

The new version goes from [0, 2pi) exclusive, and splits the circle into 8 segments (rather than 10).

I believe that there's still a drawback in this implementation that it misses detail which is finer than the thickness, since it only samples one point at each angle at thickness-offset; this is mostly a problem for figures which are concave or made of multiple parts (, like a container). I'm not sure what the efficient solution to that is, and I'm a shader newb so I might be wrong.
I'm not sure why it was splitting the circle into 10 segments; the commented out code at the bottom *implies* this is a measure to improve quality by increasing samples. But then, see my concern about details around concave figures, where IMO a larger concern about quality is that all samples are at the perimeter of a circle, so.