### PR TITLE
Update CursorKeys.js

### DIFF
--- a/plugins/utils/input/CursorKeys.js
+++ b/plugins/utils/input/CursorKeys.js
@@ -16,8 +16,8 @@ class CursorKeys {
     shutdown(fromScene) {
         for (var key in this.cursorKeys) {
             this.cursorKeys[key].destroy();
-            delete this.cursorKeys;
         }
+        delete this.cursorKeys;
     }
 
     destroy(fromScene) {


### PR DESCRIPTION
The virtual joystick plugin fails when switching from one scene to another.
Ex:
"CursorKeys.js:18 Uncaught TypeError: Cannot read property 'down' of undefined at TouchCursor.shutdown (CursorKeys.js:18)"

This happens because the object inside the for loop is deleted