### PR TITLE
Fix several bugs in ContainerLite child tweening

### DIFF
--- a/plugins/gameobjects/containerlite/ContainerLite.d.ts
+++ b/plugins/gameobjects/containerlite/ContainerLite.d.ts
@@ -115,11 +115,11 @@ export default class ContainerLite extends Phaser.GameObjects.Zone {
 
     tween(
         config: Phaser.Types.Tweens.TweenBuilderConfig | object
-    ): this
+    ): Phaser.Tweens.Tween
 
     tweenChild(
         config: Phaser.Types.Tweens.TweenBuilderConfig | object
-    ): this
+    ): Phaser.Tweens.Tween
 
     getChildren(
         out?: Phaser.GameObjects.GameObject[]

--- a/plugins/gameobjects/containerlite/Tween.js
+++ b/plugins/gameobjects/containerlite/Tween.js
@@ -24,7 +24,12 @@ export default {
 
         tweenConfig.targets = localTargets;
         var tween = scene.tweens.add(tweenConfig);
-        tween.on('update', function (tween, key, target) {
+        var tweenUpdateListener = function (tween, key, target) {
+            if (!target.parent) {
+                // target object was removed, so remove this tween too to avoid crashing
+                scene.tweens.remove(tween);
+                return;
+            }
             var parent = target.parent;
             var child = target.self;
             switch (key) {
@@ -46,8 +51,8 @@ export default {
                     parent.updateChildAlpha(child);
                     break;
             }
-
-        })
+        };
+        tween.on('update', tweenUpdateListener);
 
         return tween;
     },

--- a/plugins/gameobjects/containerlite/utils/GetLocalState.js
+++ b/plugins/gameobjects/containerlite/utils/GetLocalState.js
@@ -1,6 +1,23 @@
 var GetLocalState = function (gameObject) {
     if (!gameObject.hasOwnProperty('rexContainer')) {
-        gameObject.rexContainer = {};
+        var rexContainer = {};
+        Object.defineProperty(rexContainer, 'displayWidth', {
+            get: function () {
+                return gameObject.width * this.scaleX;
+            },
+            set: function (width) {
+                this.scaleX = width / gameObject.width;
+            }
+        });
+        Object.defineProperty(rexContainer, 'displayHeight', {
+            get: function () {
+                return gameObject.height * this.scaleY;
+            },
+            set: function (height) {
+                this.scaleY = height / gameObject.height;
+            }
+        });
+        gameObject.rexContainer = rexContainer;
     }
     return gameObject.rexContainer;
 }


### PR DESCRIPTION
* Fix TypeScript definitions - they return Phaser.Tweens.Tween
* Define displayWidth/displayHeight on the rexContainer object to allow proper tweening on these properties
* If the parent of the rexContainer does not exist any longer, remove the tween