### PR TITLE
FIX: Wrong variable name

### DIFF
--- a/plugins/math/raycaster/Obstacles.js
+++ b/plugins/math/raycaster/Obstacles.js
@@ -84,7 +84,7 @@ class Obstacles {
         }
 
         SpliceOne(this.gameObjects, index);
-        SpliceOne(this.polygon, index);
+        SpliceOne(this.polygons, index);
 
         this.removeDestroyCallback(gameObject);
         return this;


### PR DESCRIPTION
This little accident resulted in an exception everytime you'd remove an obstacle, for example by destroying the associated object.