### PR TITLE
[Shatter] Fix RenderTexture.destroy being called twice

### DIFF
--- a/plugins/gameobjects/mesh/shatter/rendertexture/RenderTexture.js
+++ b/plugins/gameobjects/mesh/shatter/rendertexture/RenderTexture.js
@@ -26,8 +26,10 @@ class RenderTexture extends Image {
     destroy(fromScene) {
         super.destroy(fromScene);
 
-        this.rt.destroy();
-        this.rt = null;
+        if (this.rt !== null) {
+            this.rt.destroy();
+            this.rt = null;
+        }
     }
 }
 


### PR DESCRIPTION
Calling game.destroy() will cause RenderTexture.destroy function to be called twice and the game will crash.

![image](https://user-images.githubusercontent.com/13402645/225515229-f73ce1e2-9ecf-40cc-b08e-33b44ae79886.png)
