### PR TITLE
container lite check for parent

### DIFF
--- a/plugins/gameobjects/container/containerlite/Position.js
+++ b/plugins/gameobjects/container/containerlite/Position.js
@@ -3,11 +3,16 @@ import GetScale from './utils/GetScale.js';
 
 export default {
     updateChildPosition(child) {
+        var localState = GetLocalState(child);
+        var parent = localState.parent;
+
+        if (!parent) {
+            return this;
+        }
+
         if (child.isRexContainerLite) {
             child.syncChildrenEnable = false;
         }
-        var localState = GetLocalState(child);
-        var parent = localState.parent;
 
         if (localState.syncPosition) {
             child.x = localState.x;


### PR DESCRIPTION
In rare circumstances the parent of a sizer could be null.

From our project, it seems like a grid table is updated when the screen is resized. If the table is being scrolled the cell might not have a parent but appears to have its position updated. So this change checks for a parent to prevent the entire game from crashing.